### PR TITLE
Fix incorrect version and build number in meta.yaml

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -7,7 +7,8 @@
 {% set url = project_url.get('homepage') %}
 # this will get the version set by environment variable
 {% set version = environ.get('VERSION') %}
-{% set version_number = environ.get('GIT_DESCRIBE_NUMBER', '0') | string %}
+{% set version_number = version.split('+')[0] %}
+{% set build_number = version.split("d")[1] if "d" in version else 0 %}
 
 package:
   name: mypackagename
@@ -18,7 +19,7 @@ source:
 
 build:
   noarch: python
-  number: {{ version_number }}
+  number: {{ build_number }}
   string: py{{py}}
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv
 


### PR DESCRIPTION
# Short description of the changes:
<!-- Add a concise description here-->

Fix an issue where the version number is always zero for the tarball created with `conda mambabuild`.

# Long description of the changes:
<!-- Optional, add more details here if the short description is not suffieicnt-->

Previous version number extraction in `meta.yaml` will always yield `0` for the tarball, i.e. the package uploaded to anaconda is always `myapp-0.tar.bz2`.
This is because `GIT_DESCRIBE_NUMBER` is not set on GitHub runner.
This PR switch to calculate the version number and build number directly from output of versioningit, so that the package name can be `myapp-x.y.z-py3*.tar.bz2`.


# Manual test for the reviewer
<!-- Instructions for testing here. -->

Manual run the conda build locally and check the file name.
