### PR TITLE
add version cap for conda-build to avoid api error

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -19,7 +19,7 @@ dependencies:
   - pre-commit
   # pacakge building:
   - boa
-  - conda-build
+  - conda-build < 4  # conda-build 24.x has a bug, missing update_index from conda_build.index
   - conda-verify
   - python-build
   # test: list all test dependencies here


### PR DESCRIPTION
# Short description of the changes:
<!-- Add a concise description here-->

Lastest version (24.x) of `conda-build` has a bug where `conda_build.index` no longer has `update_index` function, which breaks packaging building.
Capping it back to previous version (3.x) to avoid this issue until it is fixed.
