### PR TITLE
Include conda-forge channel when building conda package

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -30,7 +30,7 @@ jobs:
           cd conda.recipe
           echo "versioningit $(versioningit ../)"
           # build the package
-          VERSION=$(versioningit ../) conda mambabuild --output-folder . .
+          VERSION=$(versioningit ../) conda mambabuild --channel conda-forge --output-folder . .
           conda verify noarch/mypackagename*.tar.bz2
       - name: upload conda package to anaconda
         shell: bash -l {0}


### PR DESCRIPTION
# Short description of the changes:
The `conda-forge` is necessary for mambabuild to correctly solve for both `versioningit` and `setuptools`

# Long description of the changes:
<!-- Optional, add more details here if the short description is not suffieicnt-->

# Check list for the pull request
- [ ] I have read the [CONTRIBUTING]
- [ ] I have read the [CODE_OF_CONDUCT]
- [ ] I have added tests for my changes
- [ ] I have updated the documentation accordingly

# Check list for the reviewer
- [ ] I have read the [CONTRIBUTING]
- [ ] I have verified the proposed changes
- [ ] best software practices
    + [ ] all internal functions have an underbar, as is python standard
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

# Manual test for the reviewer
<!-- Instructions for testing here. -->

# References
<!-- Links to related issues or pull requests -->
<!-- Links to IBM EWM items if aaplicable -->
