### PR TITLE
Consistent libarchive version

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true
+          channels: conda-forge,defaults
           mamba-version: "*"
           environment-file: environment.yml
           cache-environment-key: ${{ runner.os }}-env-${{ hashFiles('**/environment.yml') }}

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -31,3 +31,14 @@ jobs:
           python -m pytest --cov=src --cov-report=xml --cov-report=term-missing tests/
       - name: upload coverage to codecov
         uses: codecov/codecov-action@v1
+      - name: build conda package
+        run: |
+          # test that the conda package builds
+          cd conda.recipe
+          echo "versioningit $(versioningit ../)"
+          # conda channels could have been defined in the conda-incubator, but you can copy/paste the lines
+          # below to build the conda package in your local machine
+          CHANNELS="--channel mantid/label/main --channel conda-forge"
+          VERSION=$(versioningit ../) conda mambabuild $CHANNELS --output-folder . .
+          conda verify noarch/usansred*.tar.bz2
+

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -41,4 +41,4 @@ jobs:
           # below to build the conda package in your local machine
           CHANNELS="--channel mantid/label/main --channel conda-forge"
           VERSION=$(versioningit ../) conda mambabuild $CHANNELS --output-folder . .
-          conda verify noarch/usansred*.tar.bz2
+          conda verify noarch/mypackagename*.tar.bz2

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -41,4 +41,3 @@ jobs:
           CHANNELS="--channel mantid/label/main --channel conda-forge"
           VERSION=$(versioningit ../) conda mambabuild $CHANNELS --output-folder . .
           conda verify noarch/usansred*.tar.bz2
-

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true
+          channels: conda-forge,defaults
           mamba-version: "*"
           environment-file: environment.yml
           cache-environment-key: ${{ runner.os }}-env-${{ hashFiles('**/environment.yml') }}

--- a/environment.yml
+++ b/environment.yml
@@ -20,6 +20,7 @@ dependencies:
   # pacakge building:
   - libmamba
   - libarchive
+  - anaconda-client
   - boa
   - conda-build < 4  # conda-build 24.x has a bug, missing update_index from conda_build.index
   - conda-verify

--- a/environment.yml
+++ b/environment.yml
@@ -18,6 +18,8 @@ dependencies:
   # utils:
   - pre-commit
   # pacakge building:
+  - libmamba
+  - libarchive
   - boa
   - conda-build < 4  # conda-build 24.x has a bug, missing update_index from conda_build.index
   - conda-verify


### PR DESCRIPTION
# Short description of the changes:
A conda environment containing dependencies from different channels (mantid, conda-forge, defaults) often leads to the following [error](https://github.com/neutrons/usansred/actions/runs/8427714349/job/23078817418) when trying to build the conda package:
```bash
from libmambapy.bindings import *  # noqa: F401,F403
ImportError: libarchive.so.19: cannot open shared object file: No such file or directory
```

# Long description of the changes:
- Explicit requirements of `libmamba` and `libarchive` so that both will be installed from the same conda channel.
- commented out build conda package in the unittest workflow. We should be testing the conda package even though we won't publish it
- add dependency `anaconda-client` to ensure command `anaconda` is available and [prevent this error when uploading a conda package just built](https://github.com/neutrons/usansred/actions/runs/8434290559/job/23097193935#step:6:16)

# Check list for the pull request
- [ ] I have read the [CONTRIBUTING]
- [ ] I have read the [CODE_OF_CONDUCT]
- [ ] I have added tests for my changes
- [ ] I have updated the documentation accordingly

# Check list for the reviewer
- [ ] I have read the [CONTRIBUTING]
- [ ] I have verified the proposed changes
- [ ] best software practices
    + [ ] all internal functions have an underbar, as is python standard
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

# Manual test for the reviewer
<!-- Instructions for testing here. -->

# References
<!-- Links to related issues or pull requests -->
<!-- Links to IBM EWM items if aaplicable -->
