### PR TITLE
Use "_static" only if it exists

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -66,7 +66,9 @@ autosummary_generate = True
 napoleon_google_docstring = False
 napoleon_numpy_docstring = True
 
-html_static_path = ["_static"]
+# "Static" resources (like *.css *.js files, or images) to be included when generating the HTML documentation.
+if os.path.exists("_static"):
+    html_static_path = ["_static"]
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = True


### PR DESCRIPTION
if the directory doesn't exists, `make html` will raise an exception
