### PR TITLE
fix missing mamba issue in github action

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -18,10 +18,9 @@ jobs:
         with:
           auto-update-conda: true
           channels: conda-forge,defaults
-          mamba-version: "*"
+          use-mamba: true
           environment-file: environment.yml
-          cache-environment-key: ${{ runner.os }}-env-${{ hashFiles('**/environment.yml') }}
-          cache-downloads-key: ${{ runner.os }}-downloads-${{ hashFiles('**/environment.yml') }}
+          activate-environment: test
       - name: install additional dependencies
         run: |
           echo "installing additional dependencies from environment_development.yml"
@@ -61,10 +60,9 @@ jobs:
         with:
           auto-update-conda: true
           channels: conda-forge,defaults
-          mamba-version: "*"
+          use-mamba: true
           environment-file: environment.yml
-          cache-environment-key: ${{ runner.os }}-env-${{ hashFiles('**/environment.yml') }}
-          cache-downloads-key: ${{ runner.os }}-downloads-${{ hashFiles('**/environment.yml') }}
+          activate-environment: test
       - name: build pypi package
         run: |
           # build the package

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -19,10 +19,9 @@ jobs:
         with:
           auto-update-conda: true
           channels: conda-forge,defaults
-          mamba-version: "*"
+          use-mamba: true
           environment-file: environment.yml
-          cache-environment-key: ${{ runner.os }}-env-${{ hashFiles('**/environment.yml') }}
-          cache-downloads-key: ${{ runner.os }}-downloads-${{ hashFiles('**/environment.yml') }}
+          activate-environment: test
       - name: install additional dependencies
         run: |
           echo "installing additional dependencies if cannot be installed from conda"


### PR DESCRIPTION
# Short description of the changes:
<!-- Add a concise description here-->

This PR resolves an issue related to `missing mamba` in `test` environment.

# Long description of the changes:
<!-- Optional, add more details here if the short description is not suffieicnt-->

`setup-miniconda@v3` changed recently and is leading to failing related to the issue described above.
This PR resolve this issue by

- remove unsupported field
- switch to preferred mamba selection criteria
- force activate `test` environment at the end of the setup
