### PR TITLE
Remove conda `defaults` channel

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v3
         with:
           auto-update-conda: true
-          channels: conda-forge,defaults
+          channels: conda-forge
           use-mamba: true
           environment-file: environment.yml
           activate-environment: test
@@ -59,7 +59,7 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v3
         with:
           auto-update-conda: true
-          channels: conda-forge,defaults
+          channels: conda-forge
           use-mamba: true
           environment-file: environment.yml
           activate-environment: test

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v3
         with:
           auto-update-conda: true
-          channels: conda-forge,defaults
+          channels: conda-forge
           use-mamba: true
           environment-file: environment.yml
           activate-environment: test


### PR DESCRIPTION
# Short description of the changes:
Remove the conda `defaults` channel, since it requires a license for organizations with 200 or more people according to Anaconda's terms of service: https://www.anaconda.com/blog/is-conda-free#summarize.

# Check list for the pull request
- [x] I have read the [CONTRIBUTING]
- [x] I have read the [CODE_OF_CONDUCT]
- [ ] ~~I have added tests for my changes~~
- [ ] ~~I have updated the documentation accordingly~~

# Check list for the reviewer
- [ ] I have read the [CONTRIBUTING]
- [ ] I have verified the proposed changes
- [ ] best software practices
    + [ ] all internal functions have an underbar, as is python standard
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

# Manual test for the reviewer
<!-- Instructions for testing here. -->

# References
<!-- Links to related issues or pull requests -->
<!-- Links to IBM EWM items if aaplicable -->
