### PR TITLE
remove checkout step from conda verify action

### DIFF
--- a/.github/workflows/test_and_deploy.yaml
+++ b/.github/workflows/test_and_deploy.yaml
@@ -74,12 +74,6 @@ jobs:
       run:
         shell: bash -el {0}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          fetch-tags: true
-
       - name: Setup micromamba
         uses: mamba-org/setup-micromamba@v2
         with:


### PR DESCRIPTION
# Short description of the changes:
Removing the checkout from this job as the repo isnt used at all to conda verify.
This being present actually led to quite a bit of debugging the job in the `addie` repo because how how the `addie` project is setup.

`addie` is not nested in a `src` folder, so when the verify step attempts to access its version it does not actually refer to the just installed package `addie` but instead the repo files that have been checked out.
Since the checked out files do not have a `_verison.py` file, it fails.
This is incorrect behavior.  
Since it is unnecessary, I think the checkout action should be removed.