### PR TITLE
Add hook for gitleaks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,6 +29,10 @@ repos:
     hooks:
       - id: codespell
         exclude: "tests/cis_tests/.*"
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.29.0
+    hooks:
+      - id: gitleaks
   - repo: https://github.com/adrienverge/yamllint/
     rev: v1.37.1
     hooks:


### PR DESCRIPTION
[Gitleaks](https://github.com/gitleaks/gitleaks) is a tool for detecting secrets like passwords, API keys, and tokens in git repos, files, etc.

We haven't inserted anything that the tool detects as a secret. This hook will help keep it that way.