### PR TITLE
Configure Dependabot to group all actions dependencies into one PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,10 @@ updates:
     directory: "/" # Workflow files stored in the default location of `.github/workflows`
     schedule:
       interval: "weekly"
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"  # include all actions in a single PR
   - package-ecosystem: "pip"
     directory: "/"
     schedule:


### PR DESCRIPTION
Add grouping for all dependencies in GitHub Actions into one PR.

# Short description of the changes:
<!-- Add a concise description here-->

# Long description of the changes:
<!-- Optional, add more details here if the short description is not suffieicnt-->

# Check list for the pull request
- [ ] I have read the [CONTRIBUTING]
- [ ] I have read the [CODE_OF_CONDUCT]
- [ ] I have added tests for my changes
- [ ] I have updated the documentation accordingly

# Check list for the reviewer
- [ ] I have read the [CONTRIBUTING]
- [ ] I have verified the proposed changes
- [ ] best software practices
    + [ ] all internal functions have an underbar, as is python standard
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

# Manual test for the reviewer
<!-- Instructions for testing here. -->

# References
<!-- Links to related issues or pull requests -->
<!-- Links to IBM EWM items if aaplicable -->
