### PR TITLE
Add an environment for copilot to use when making changes

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,35 @@
+name: "Copilot Setup Steps"
+
+# Automatically run the setup steps when they are changed to allow for easy validation, and
+# allow manual testing through the repository's "Actions" tab
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+  pull_request:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+
+jobs:
+  # The job MUST be called `copilot-setup-steps` or it will not be picked up by Copilot.
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+
+    # Set the permissions to the lowest permissions possible needed for your steps.
+    # Copilot will be given its own token for its operations.
+    permissions:
+      # If you want to clone the repository as part of your setup steps, for example to install
+      # dependencies, you'll need the `contents: read` permission. If you don't clone the repository
+      # in your setup steps, Copilot will do this for you automatically after the steps complete.
+      contents: read
+
+    # You can define any steps you want, and they will run before the agent starts.
+    # If you do not check out your code, Copilot will do this for you.
+
+    # this will install pre-commit into a python environment
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v3
+      - run: python -m pip install pre-commit
+        shell: bash


### PR DESCRIPTION
This is a variant of https://github.com/mantidproject/mantid/pull/40289 that sets up a minimal python environment with pre-commit installed so copilot can make sure that those rules are adhered to when making PRs.