### PR TITLE
Target the branch that started the workflow

### DIFF
--- a/.github/workflows/update-lockfiles.yml
+++ b/.github/workflows/update-lockfiles.yml
@@ -15,6 +15,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        # checks out refspec that triggered or the default branch
 
       - name: Setup pixi
         uses: prefix-dev/setup-pixi@v0.9.4
@@ -28,13 +29,13 @@ jobs:
 
       - name: Create pull request
         uses: peter-evans/create-pull-request@v8
+        # PR will target the branch checked out in the workflow
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: Update pixi lockfile
           title: Update pixi lockfile
           body-path: diff.md
           branch: update-pixi
-          base: main # change this to the default branch of your repository
           labels: pixi
           delete-branch: true
           add-paths: pixi.lock


### PR DESCRIPTION
[actions/check](https://github.com/actions/checkout), by default, checks out
```
# The branch, tag or SHA to checkout. When checking out the repository that
# triggered a workflow, this defaults to the reference or SHA for that event.
# Otherwise, uses the default branch.
```
and [peter-evans/create-pull-request](https://github.com/peter-evans/create-pull-request) sets the base branch for the PR to
```
Defaults to the branch checked out in the workflow.
```
This means that the `base` branch does not need to be specified in the workflow. 

When this matters:

**Scheduled runs** use the default branch of the repository. Specifying the `base` branch for the PR is redundant. 

**`workflow_dispatch` runs** allow the person that starts them to select a branch to run it against. This was discovered when trying to run the workflow in vnext.

The extra benefit is that this version of the workflow does not need to edited by repositories that copy it.