### PR TITLE
Fix pip-audit failures for CVE-2026-34073 and CVE-2026-25645

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -2108,8 +2108,8 @@ packages:
   timestamp: 1733208220327
 - pypi: ./
   name: examplepyapp
-  version: 0.1.0
-  sha256: b9f44469b8ffde9de9492dfb1d2d4863a2b13ff0c914585b9be3d1f6f22cb641
+  version: 1.1.0.dev20260406191706
+  sha256: 30e61e2054530cc83e4e856ceacda0d350eae4351942af68fe419466eacea75d
   requires_dist:
   - bm3d-streak-removal>=0.2.0,<0.3
   - numpy>=2.2,<3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,7 @@ urllib3 = ">=2.6.3"          # Known vulnerability in <2.6.3
 filelock = ">=3.20.3"        # Known vulnerability in <3.20.3
 virtualenv = ">=20.36.1,<21" # Known vulnerability in <20.36.1; capped due to https://github.com/pypa/hatch/issues/2193
 cryptography = ">=46.0.5"    # CVE-2026-26007
+requests = ">=2.33.0"        # CVE-2026-25645
 pillow = ">=12.1.1"          # CVE-2026-25990
 
 [tool.pixi.pypi-dependencies]
@@ -214,7 +215,7 @@ conda-publish = { cmd = "anaconda upload *.conda", description = "Publish the .c
   "conda-build",
 ] }
 # Misc
-audit-deps = { cmd = "pip-audit --local -s osv --ignore-vuln CVE-2026-4539", description = "Audit the package dependencies for vulnerabilities" }
+audit-deps = { cmd = "pip-audit --local -s osv --ignore-vuln CVE-2026-4539 --ignore-vuln CVE-2026-34073", description = "Audit the package dependencies for vulnerabilities" }
 # Cleaning
 clean = { cmd = 'rm -rf .pytest_cache .ruff_cache **/*.egg-info **/dist **/__pycache__', description = "Clean up various caches and build artifacts" }
 clean-conda = { cmd = "rm -f *.conda", description = "Clean the local .conda build artifacts" }


### PR DESCRIPTION
## Summary
- Pin `requests >= 2.33.0` to resolve CVE-2026-25645 (fix available in conda-forge)
- Add `--ignore-vuln CVE-2026-34073` for `cryptography` since 46.0.6 is not yet available in conda-forge
- Update pixi lockfile

Fixes CI failures in #155 and #157.

## Test plan
- [x] `pixi run audit-deps` passes locally
- [x] `pixi run test` passes locally
- [ ] CI passes on this PR
- [ ] After merge, re-run CI on #155 and #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)