### PR TITLE
Update workflows to gh-actions v2

### DIFF
--- a/.github/workflows/test_and_deploy.yaml
+++ b/.github/workflows/test_and_deploy.yaml
@@ -95,24 +95,24 @@ jobs:
       # installed (and micromamba on PATH); pkg-install sets both up.
       - name: Install built conda package
         id: install
-        uses: neutrons/gh-actions/pkg-install@a1e1c8b4123ced6c66fe57b9a60a56a6e4bf6861 # v1
+        uses: neutrons/gh-actions/pkg-install@eb7a7c6fcfd0cda1a7b238329afc0afd09a4f4af # v2
         with:
           package-name: ${{ env.PKG_NAME }}
           local-channel: ./local-channel
 
       - name: Verify conda package
-        uses: neutrons/gh-actions/pkg-verify@a1e1c8b4123ced6c66fe57b9a60a56a6e4bf6861 # v1
+        uses: neutrons/gh-actions/pkg-verify@eb7a7c6fcfd0cda1a7b238329afc0afd09a4f4af # v2
         with:
           package-name: ${{ env.PKG_NAME }}
           module-name: ${{ env.MODULE_NAME }}
-          conda-env-name: ${{ steps.install.outputs.conda_env }}
+          conda-env-name: ${{ steps.install.outputs.conda-env }}
 
       # Audit the dependencies of the conda package we just installed. SARIF
       # results are uploaded to GitHub code scanning by the grype action.
       - name: Scan installed environment with Grype
-        uses: neutrons/gh-actions/grype@a1e1c8b4123ced6c66fe57b9a60a56a6e4bf6861 # v1
+        uses: neutrons/gh-actions/grype@eb7a7c6fcfd0cda1a7b238329afc0afd09a4f4af # v2
         with:
-          path: ${{ steps.install.outputs.conda_install_dir }}
+          path: ${{ steps.install.outputs.conda-install-dir }}
 
       - name: Upload conda package as artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -150,7 +150,7 @@ jobs:
           name: artifact-conda-package
 
       - name: Upload package to anaconda
-        uses: neutrons/gh-actions/publish@a1e1c8b4123ced6c66fe57b9a60a56a6e4bf6861 # v1
+        uses: neutrons/gh-actions/publish@eb7a7c6fcfd0cda1a7b238329afc0afd09a4f4af # v2
         with:
           anaconda-token: ${{ secrets.ANACONDA_TOKEN }}
           organization: neutrons
@@ -158,11 +158,11 @@ jobs:
 
       - name: Remove old packages
         if: github.ref == 'refs/heads/next'
-        uses: neutrons/gh-actions/pkg-remove@a1e1c8b4123ced6c66fe57b9a60a56a6e4bf6861 # v1
+        uses: neutrons/gh-actions/pkg-remove@eb7a7c6fcfd0cda1a7b238329afc0afd09a4f4af # v2
         with:
-          anaconda_token: ${{ secrets.ANACONDA_TOKEN }}
+          anaconda-token: ${{ secrets.ANACONDA_TOKEN }}
           organization: neutrons
-          package_name: ${{ env.PKG_NAME }}
+          package-name: ${{ env.PKG_NAME }}
           label: ${{ env.CONDA_LABEL }}
           keep: 5
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,8 +161,8 @@ pytest-repeat = "*"
 pytest-xdist = "*"
 
 [tool.pixi.feature.package.dependencies]
-twine = ">=6.1.0,<7"  # for PyPI publishing
-hatch = "*"  # for building wheels and sdist
+twine = ">=6.1.0,<7" # for PyPI publishing
+hatch = "*"          # for building wheels and sdist
 versioningit = "*"
 
 [tool.pixi.feature.package.pypi-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,9 +161,9 @@ pytest-repeat = "*"
 pytest-xdist = "*"
 
 [tool.pixi.feature.package.dependencies]
-twine = ">=6.1.0,<7"
+twine = ">=6.1.0,<7"  # for PyPI publishing
+hatch = "*"  # for building wheels and sdist
 versioningit = "*"
-hatch = "*"
 
 [tool.pixi.feature.package.pypi-dependencies]
 toml-cli = "*"


### PR DESCRIPTION
# Short description of the changes:

See title. Also adds minor comments to clarify when twine and hatch are actually needed as build dependencies (not needed if not publishing to pypi)

# Check list for the pull request
- [x] I have read the [CONTRIBUTING]
- [x] I have read the [CODE_OF_CONDUCT]
- [ ] ~~I have added tests for my changes~~
- [ ] ~~I have updated the documentation accordingly~~

# Check list for the reviewer
- [ ] I have read the [CONTRIBUTING]
- [ ] I have verified the proposed changes
- [ ] best software practices
    + [ ] all internal functions have an underbar, as is python standard
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

# Manual test for the reviewer
<!-- Instructions for testing here. -->

# References

https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=17062
