### PR TITLE
Make pre-commit install get pre-push

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,5 @@
+default_install_hook_types: [pre-commit, pre-push]
+
 exclude: "^pixi.lock$"
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
Turns out there is a better way:
https://pre-commit.com/#confining-hooks-to-run-at-certain-stages

Then you run `pre-commit install` again and everything "just works."
